### PR TITLE
Fix wordcloud to be responsive under 400px

### DIFF
--- a/src/components/WordCloud.css
+++ b/src/components/WordCloud.css
@@ -46,7 +46,6 @@ body {
  * Layout
  */
 .wordcloud__container_cloud {
-  max-width: 100%;
   flex: 0 0 400px;
   text-align: center;
 }


### PR DESCRIPTION
Deleted max-width on .wordcloud__container_cloud. This should make the cloud responsive under 400px. The cloud size I don't think is resizeable though under 400px.